### PR TITLE
Flux: Ensure connections to InflxuDB are closed

### DIFF
--- a/pkg/tsdb/influxdb/flux/flux.go
+++ b/pkg/tsdb/influxdb/flux/flux.go
@@ -41,6 +41,7 @@ func Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQ
 
 		tRes.Results[query.RefId] = backendDataResponseToTSDBResponse(&res, query.RefId)
 	}
+	defer runner.client.Close()
 	return tRes, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures TCP connections created between the  Grafana Flux datasource and InFluxDB are closed after they have been used.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/26731

**Special notes for your reviewer**:

