### PR TITLE
Flux: Increase series limit for Flux queries

### DIFF
--- a/pkg/tsdb/influxdb/flux/flux.go
+++ b/pkg/tsdb/influxdb/flux/flux.go
@@ -37,7 +37,7 @@ func Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQ
 			continue
 		}
 
-		res := ExecuteQuery(context.Background(), *qm, runner, 10)
+		res := ExecuteQuery(context.Background(), *qm, runner, 50)
 
 		tRes.Results[query.RefId] = backendDataResponseToTSDBResponse(&res, query.RefId)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Increases the limit for the number of series / tables that can be displayed for a dashboard using flux.  The increase is from 10 to 50.

**Which issue(s) this PR fixes**:

Fixes #26632

**Special notes for your reviewer**:

